### PR TITLE
Add Sentry integration for rust

### DIFF
--- a/calendar-service/Cargo.toml
+++ b/calendar-service/Cargo.toml
@@ -15,6 +15,7 @@ chrono = "0.4.22"
 chrono-tz = "0.7.0"
 aes-gcm = "0.10.1"
 generic-array = "0.14.6"
+sentry = "0.29.1"
 
 [build-dependencies]
 tonic-build = "0.8.0"

--- a/calendar-service/calendar-service.Dockerfile
+++ b/calendar-service/calendar-service.Dockerfile
@@ -10,7 +10,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 # Build dependencies
 FROM rust:1.64-alpine3.16 AS cacher
 WORKDIR /usr/src/app
-RUN apk add musl-dev
+RUN apk add musl-dev libressl-dev
 RUN cargo install cargo-chef
 COPY --from=planner /usr/src/app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
@@ -18,7 +18,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 # Build stage
 FROM rust:1.64-alpine3.16 as builder
 WORKDIR /usr/src/app
-RUN apk add build-base protoc protobuf-dev
+RUN apk add build-base protoc protobuf-dev libressl-dev
 COPY --from=cacher /usr/src/app/target target
 COPY --from=cacher /usr/local/cargo /usr/local/cargo
 COPY . .

--- a/calendar-service/src/main.rs
+++ b/calendar-service/src/main.rs
@@ -77,7 +77,7 @@ impl Calendar for CalendarService {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Sentry integration
     let _guard = sentry::init((
-        env::var("SENTRY_DSN").expect("Expected SENTRY_DSN to be set"),
+        env::var("SENTRY_DSN").unwrap(),
         sentry::ClientOptions {
             release: sentry::release_name!(),
             sample_rate: 1.0,

--- a/calendar-service/src/main.rs
+++ b/calendar-service/src/main.rs
@@ -75,6 +75,17 @@ impl Calendar for CalendarService {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Sentry integration
+    let _guard = sentry::init((
+        env::var("SENTRY_DSN").expect("Expected SENTRY_DSN to be set"),
+        sentry::ClientOptions {
+            release: sentry::release_name!(),
+            sample_rate: 1.0,
+            traces_sample_rate: 0.2,
+            ..Default::default()
+        },
+    ));
+
     println!("Starting calendars server...");
     let grpc_port = env::var("GRPC_PORT").expect("Expected GRPC_PORT to be set");
     let addr = format!("0.0.0.0:{}", grpc_port).parse()?;

--- a/calendar-service/src/service.rs
+++ b/calendar-service/src/service.rs
@@ -157,8 +157,8 @@ pub mod calendar {
         use super::*;
         use crate::calendar::CalendarEntity;
         use prost_types::Timestamp;
-        use std::env;
         use serial_test::serial;
+        use std::env;
 
         #[test]
         fn test_create_event() {

--- a/deploy/services/calendars.env.sample
+++ b/deploy/services/calendars.env.sample
@@ -4,3 +4,4 @@ RUST_BACKTRACE=true
 GRPC_PORT=50051
 # Should be utf-8 32 Byte random string
 ENCRYPTION_KEY=
+SENTRY_DSN=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,7 @@ services:
       RUST_BACKTRACE: true
       GRPC_PORT: 50051
       ENCRYPTION_KEY: f149VI7P9EsUkirKOnGNy9YKQtbZKEAj
+      SENTRY_DSN: 
     volumes:
       - ./calendar-service/data/:/data/
     networks:


### PR DESCRIPTION
Unable to run the image right now.

## Errors: ##
If it is running in distroless image:

```
error while loading shared libraries: libssl.so.52: cannot open shared object file: No such file or directory
```

In alpine it has the same `openssl` related errors.
If I run `ldd /usr/local/bin/calendar-service` I will get these missing dependencies / paths:

```
libssl.so.52 => /usr/lib/libssl.so.52 (0xffff894f9000)
libcrypto.so.49 => /usr/lib/libcrypto.so.49 (0xffff89314000)
libc.musl-aarch64.so.1 => /lib/ld-linux-aarch64.so.1 (0xffff8955f000)
```

I've tried several solutions on the internet, but they didn't work. At least on M1.

Closes #33 